### PR TITLE
Determinant calculation added. Needs tests.

### DIFF
--- a/include/MafLib/math/linalg/Matrix.hpp
+++ b/include/MafLib/math/linalg/Matrix.hpp
@@ -363,8 +363,19 @@ class Matrix {
       vDSP_mtransD(_data.data(), 1, result.data(), 1, _cols, _rows);
       return result;
     }
+#elif defined(__OPENBLAS_AVAILABLE)
+    if constexpr (std::is_same_v<T, float>) {
+      cblas_somatcopy(CblasRowMajor, CblasTrans, _rows, _cols, 1.0f, _data.data(),
+                      _cols, result.data(), _rows);
+      return result;
+    } else if constexpr (std::is_same_v<T, double>) {
+      cblas_domatcopy(CblasRowMajor, CblasTrans, _rows, _cols, 1.0, _data.data(), _cols,
+                      result.data(), _rows);
+      return result;
+    }
+  }
 #endif
-    // Default non-Apple implementation
+    // Generic implementation
 #pragma omp parallel for collapse(2) schedule(static) default(none) shared(result)
     for (size_t i = 0; i < _rows; i += BLOCK_SIZE) {
       for (size_t j = 0; j < _cols; j += BLOCK_SIZE) {
@@ -379,6 +390,35 @@ class Matrix {
       }
     }
     return result;
+  }
+
+  template <bool is_spd = false>
+  [[nodiscard]] T determinant() const {
+    if (!is_square()) {
+      throw std::invalid_argument("Determinant is only defined for square matrices.");
+    }
+
+    if constexpr (is_spd) {
+      // res = det(L)^2
+      T det = 1;
+      auto L = cholesky(*this);
+
+      for (size_t i = 0; i < _rows; ++i) {
+        det *= L(i, i);
+      }
+
+      return det * det;
+    } else {
+      // res = det(U) * det(P), det(L) = 1
+      auto plu_res = plu(*this);
+      T det = plu_res.sign;
+
+      for (size_t i = 0; i < _rows; ++i) {
+        det *= plu_res.U(i, i);
+      }
+
+      return det;
+    }
   }
 
   // TODO: Implement
@@ -564,8 +604,8 @@ class Matrix {
       _fallback_matrix_multiply(a_data, b_data, c_data, a_rows, a_cols, b_cols);
     }
 #else
-    // Default non-Apple implementation
-    _fallback_matrix_multiply(a_data, b_data, c_data, a_rows, a_cols, b_cols);
+  // Default non-Apple implementation
+  _fallback_matrix_multiply(a_data, b_data, c_data, a_rows, a_cols, b_cols);
 #endif
     return result;
   }

--- a/include/MafLib/math/linalg/Matrix.hpp
+++ b/include/MafLib/math/linalg/Matrix.hpp
@@ -393,43 +393,34 @@ class Matrix {
   }
 
   template <bool is_spd = false>
-  [[nodiscard]] T determinant() const {
+  [[nodiscard]] auto determinant() const {
     if (!is_square()) {
       throw std::invalid_argument("Determinant is only defined for square matrices.");
     }
 
-    // PLU/Cholesky compute in floating point, so accumulate there to avoid
-    // truncating intermediate products for integral element types (T).
-    using AccumType = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-
-    const auto finalize = [](AccumType value) -> T {
-      if constexpr (std::is_integral_v<T>) {
-        return static_cast<T>(std::round(value));
-      } else {
-        return static_cast<T>(value);
-      }
-    };
-
     if constexpr (is_spd) {
       // res = det(L)^2
       auto L = cholesky(*this);
+      using AccumType =
+          typename std::decay_t<decltype(L)>::value_type;  // Get the promoted type
       AccumType det = 1;
 
       for (size_t i = 0; i < _rows; ++i) {
         det *= L.at(i, i);
       }
-
-      return finalize(det * det);
+      return det * det;
     } else {
       // res = det(U) * det(P), det(L) = 1
       auto plu_res = plu(*this);
-      AccumType det = static_cast<AccumType>(plu_res.sign);
+      using AccumType =
+          typename std::decay_t<decltype(plu_res.U)>::value_type;  // Get the promoted
+                                                                   // type
+      auto det = static_cast<AccumType>(plu_res.sign);
 
       for (size_t i = 0; i < _rows; ++i) {
         det *= plu_res.U.at(i, i);
       }
-
-      return finalize(det);
+      return det;
     }
   }
 

--- a/include/MafLib/math/linalg/Matrix.hpp
+++ b/include/MafLib/math/linalg/Matrix.hpp
@@ -398,26 +398,38 @@ class Matrix {
       throw std::invalid_argument("Determinant is only defined for square matrices.");
     }
 
+    // PLU/Cholesky compute in floating point, so accumulate there to avoid
+    // truncating intermediate products for integral element types (T).
+    using AccumType = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+
+    const auto finalize = [](AccumType value) -> T {
+      if constexpr (std::is_integral_v<T>) {
+        return static_cast<T>(std::round(value));
+      } else {
+        return static_cast<T>(value);
+      }
+    };
+
     if constexpr (is_spd) {
       // res = det(L)^2
-      T det = 1;
       auto L = cholesky(*this);
+      AccumType det = 1;
 
       for (size_t i = 0; i < _rows; ++i) {
-        det *= L(i, i);
+        det *= L.at(i, i);
       }
 
-      return det * det;
+      return finalize(det * det);
     } else {
       // res = det(U) * det(P), det(L) = 1
       auto plu_res = plu(*this);
-      T det = plu_res.sign;
+      AccumType det = static_cast<AccumType>(plu_res.sign);
 
       for (size_t i = 0; i < _rows; ++i) {
-        det *= plu_res.U(i, i);
+        det *= plu_res.U.at(i, i);
       }
 
-      return det;
+      return finalize(det);
     }
   }
 

--- a/include/MafLib/math/linalg/PLU.hpp
+++ b/include/MafLib/math/linalg/PLU.hpp
@@ -21,6 +21,23 @@
  * https://en.wikipedia.org/wiki/LU_decomposition#LU_factorization_with_partial_pivoting
  */
 namespace maf::math {
+/**
+ * @brief Struct to hold the result of a PLU decomposition.
+ *
+ * This struct contains the permutation vector P, the lower triangular
+ * matrix L, the upper triangular matrix U, and the sign of the permutation.
+ *
+ * @tparam T The floating point type of the matrix elements (e.g., float,
+ * double).
+ */
+template <std::floating_point T>
+struct PLUResult {
+  std::vector<uint32> P;  // Permutation vector
+  Matrix<T> L;            // Lower triangular matrix
+  Matrix<T> U;            // Upper triangular matrix
+  int8 sign = 1;          // Sign of the permutation (+1 or -1)
+};
+
 namespace detail {
 /**
  * @brief Internal implementation of PLU decomposition.
@@ -29,8 +46,7 @@ namespace detail {
  * Uses blocked algorithm with OpenMP parallelization.
  */
 template <std::floating_point T>
-[[nodiscard]] std::tuple<std::vector<uint32>, Matrix<T>, Matrix<T>> _plu(
-    Matrix<T> &&_U) {
+[[nodiscard]] PLUResult<T> _plu(Matrix<T> &&_U) {
   if (!_U.is_square()) {
     throw std::invalid_argument("Matrix must be square for PLU decomposition!");
   }
@@ -45,6 +61,7 @@ template <std::floating_point T>
   // std::ranges::iota(P, 0);
   std::iota(P.begin(), P.end(), 0);
   Matrix<T> L = identity_matrix<T>(n);
+  int8 sign = 1;
 
   // Conceptual block matrix:
   // A = [A_11, A_12]
@@ -74,6 +91,7 @@ template <std::floating_point T>
       if (pivot_row != i) {
         // Swap permutation vector
         std::swap(P[i], P[pivot_row]);
+        sign *= -1;
 
         // Swap entire rows in our working matrix
         auto row_i = _U.row_span(i);
@@ -155,7 +173,7 @@ template <std::floating_point T>
     std::copy_n(a_row, len, u_row);
   }
 
-  return std::make_tuple(std::move(P), std::move(L), std::move(U));
+  return PLUResult<T>{std::move(P), std::move(L), std::move(U), sign};
 }
 
 }  // namespace detail

--- a/tests/math/linalg/MatrixTests.cpp
+++ b/tests/math/linalg/MatrixTests.cpp
@@ -980,6 +980,194 @@ class MatrixTests : public ITest {
   }
 
   //=============================================================================
+  // MATRIX DETERMINANT TESTS
+  //=============================================================================
+  void should_compute_determinant_of_1x1_matrix() {
+    math::Matrix<double> m1(1, 1, {-7.25});
+    math::Matrix<double> m2(1, 1, {3.0});
+    ASSERT_TRUE(is_close(m1.determinant(), -7.25));
+    ASSERT_TRUE(is_close(m2.determinant(), 3.0));
+  }
+
+  void should_compute_determinant_of_2x2_matrix() {
+    math::Matrix<double> m1(2, 2, {1, 2, 3, 4});
+    math::Matrix<double> m2(2, 2, {-4, -5, -2, -1});
+    ASSERT_TRUE(is_close(m1.determinant(), -2.0));
+    ASSERT_TRUE(is_close(m2.determinant(), -6.0));
+  }
+
+  void should_compute_determinant_of_3x3_matrix() {
+    math::Matrix<double> m(3, 3, {2, 1, 1, 4, -6, 0, -2, 7, 2});
+    ASSERT_TRUE(is_close(m.determinant(), -16.0));
+  }
+
+  void should_compute_determinant_of_4x4_matrix() {
+    math::Matrix<double> m(4, 4, {1, 2, 3, 4, 5, 6, 7, 8, 2, -1, 0, 3, 9, 1, -2, 5});
+    ASSERT_TRUE(is_close(m.determinant(), -120.0));
+  }
+
+  void should_compute_determinant_of_identity_matrix() {
+    math::Matrix<double> I3 = math::identity_matrix<double>(3);
+    math::Matrix<double> I4 = math::identity_matrix<double>(4);
+    ASSERT_TRUE(is_close(I3.determinant(), 1.0));
+    ASSERT_TRUE(is_close(I4.determinant(), 1.0));
+  }
+
+  void should_compute_determinant_of_diagonal_matrix() {
+    math::Matrix<double> m(3, 3, {9, 0, 0, 0, 16, 0, 0, 0, 25});
+    ASSERT_TRUE(is_close(m.determinant(), 3600.0));
+  }
+
+  void should_compute_determinant_of_triangular_matrix() {
+    math::Matrix<double> m(3, 3, {1, 2, 3, 0, 4, 5, 0, 0, 6});
+    ASSERT_TRUE(is_close(m.determinant(), 24.0));
+  }
+
+  void should_compute_determinant_of_permutation_matrix() {
+    math::Matrix<double> m(4, 4, {0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1});
+    math::Matrix<double> m2(3, 3, {1, 0, 0, 0, 0, 1, 0, 1, 0});
+    ASSERT_TRUE(is_close(m.determinant(), -1.0));
+    ASSERT_TRUE(is_close(m2.determinant(), -1.0));
+  }
+
+  void should_throw_if_determinant_called_on_non_square_matrix() {
+    math::Matrix<double> m1(2, 3, {1, 2, 3, 4, 5, 6});
+    math::Matrix<double> m2(3, 2, {1, 2, 3, 4, 5, 6});
+    ASSERT_THROW((void)m1.determinant(), std::invalid_argument);
+    ASSERT_THROW((void)m2.determinant(), std::invalid_argument);
+  }
+
+  void should_throw_for_singular_matrix_when_computing_determinant() {
+    math::Matrix<double> m(2, 2, {1, 2, 2, 4});
+    math::Matrix<double> z(3, 3, {0, 0, 0, 0, 0, 0, 0, 0, 0});
+    ASSERT_THROW((void)m.determinant(), std::runtime_error);
+    ASSERT_THROW((void)z.determinant(), std::runtime_error);
+  }
+
+  void should_throw_for_empty_matrix_when_computing_determinant() {
+    math::Matrix<int> m0;
+    ASSERT_THROW((void)m0.determinant(), std::invalid_argument);
+  }
+
+  void should_compute_determinant_of_int_matrix() {
+    math::Matrix<int> m1(2, 2, {1, 2, 3, 4});
+    math::Matrix<int> m2(2, 2, {3, 1, 1, 1});
+    math::Matrix<int> m3(3, 3, {2, 1, 1, 4, -6, 0, -2, 7, 2});
+    math::Matrix<int> m4(3, 3, {9, 0, 0, 0, 16, 0, 0, 0, 25});
+    math::Matrix<int> I = math::identity_matrix<int>(3);
+
+    ASSERT_SAME_TYPE(m1.determinant(), int);
+    ASSERT_TRUE(m1.determinant() == -2);
+    ASSERT_TRUE(m2.determinant() == 2);
+    ASSERT_TRUE(m3.determinant() == -16);
+    ASSERT_TRUE(m4.determinant() == 3600);
+    ASSERT_TRUE(I.determinant() == 1);
+  }
+
+  void should_promote_int_matrix_to_double_when_computing_determinant() {
+    // PLU/Cholesky promote integral matrices to double internally. These
+    // matrices have exact integer determinants but fractional intermediate
+    // factors, so the accumulator must not truncate during the computation.
+    math::Matrix<int> m1(3, 3, {2, 3, 1, 4, 7, 5, 6, 8, 9});
+    math::Matrix<int> m2(3, 3, {-7, -4, -8, -5, 0, -4, -7, -8, 8});
+    math::Matrix<int> m3(2, 2, {3, 1, 1, 1});
+    ASSERT_TRUE(m1.determinant() == 18);
+    ASSERT_TRUE(m2.determinant() == -368);
+    ASSERT_TRUE(m3.determinant() == 2);
+
+    math::Matrix<int> spd(3, 3, {4, 12, -16, 12, 37, -43, -16, -43, 98});
+    ASSERT_TRUE(spd.determinant<true>() == 36);
+  }
+
+  void should_compute_determinant_of_float_matrix() {
+    math::Matrix<float> m(
+        3, 3, {4.0f, 12.0f, -16.0f, 12.0f, 37.0f, -43.0f, -16.0f, -43.0f, 98.0f});
+    ASSERT_SAME_TYPE(m.determinant(), float);
+    ASSERT_TRUE(is_close(m.determinant(), 36.0f, 1e-4f));
+  }
+
+  void should_equal_determinant_of_transpose() {
+    math::Matrix<double> m(4, 4, {1, 2, 3, 4, 5, 6, 7, 8, 2, -1, 0, 3, 9, 1, -2, 5});
+    double det = m.determinant();
+    double det_t = m.transposed().determinant();
+    ASSERT_TRUE(is_close(det, -120.0));
+    ASSERT_TRUE(is_close(det, det_t));
+  }
+
+  void should_satisfy_determinant_multiplicativity() {
+    math::Matrix<double> A(3, 3, {2, 1, 1, 4, -6, 0, -2, 7, 2});
+    math::Matrix<double> B(3, 3, {1, 2, 3, 0, 4, 5, 0, 0, 6});
+    double detA = A.determinant();
+    double detB = B.determinant();
+    double detAB = (A * B).determinant();
+    ASSERT_TRUE(is_close(detA, -16.0));
+    ASSERT_TRUE(is_close(detB, 24.0));
+    ASSERT_TRUE(is_close(detAB, detA * detB));
+    ASSERT_TRUE(is_close(detAB, -384.0));
+  }
+
+  void should_compute_determinant_of_spd_matrix() {
+    math::Matrix<double> m(3, 3, {4, 12, -16, 12, 37, -43, -16, -43, 98});
+    math::Matrix<double> m2(3, 3, {1, 2, 1, 2, 5, 2, 1, 2, 10});
+    ASSERT_TRUE(is_close(m.determinant<true>(), 36.0));
+    ASSERT_TRUE(is_close(m2.determinant<true>(), 9.0));
+  }
+
+  void should_match_spd_and_plu_determinant_paths() {
+    math::Matrix<double> m(3, 3, {4, 12, -16, 12, 37, -43, -16, -43, 98});
+    math::Matrix<double> d(3, 3, {9, 0, 0, 0, 16, 0, 0, 0, 25});
+    ASSERT_TRUE(is_close(m.determinant(), m.determinant<true>()));
+    ASSERT_TRUE(is_close(m.determinant(), 36.0));
+    ASSERT_TRUE(is_close(d.determinant(), d.determinant<true>()));
+    ASSERT_TRUE(is_close(d.determinant(), 3600.0));
+  }
+
+  void should_throw_if_spd_determinant_on_non_symmetric_matrix() {
+    math::Matrix<double> m(2, 2, {1.0, 2.0, 3.0, 4.0});
+    ASSERT_THROW((void)m.determinant<true>(), std::invalid_argument);
+  }
+
+  void should_throw_if_spd_determinant_on_non_positive_definite_matrix() {
+    math::Matrix<double> m(2, 2, {1.0, 2.0, 2.0, 4.0});
+    ASSERT_THROW((void)m.determinant<true>(), std::invalid_argument);
+  }
+
+  void should_match_int_determinant_with_double_precision_computation() {
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dis(-9, 9);
+    size_t checked = 0;
+    size_t mismatches = 0;
+
+    for (size_t trial = 0; trial < 500; ++trial) {
+      math::Matrix<int> A(3, 3);
+      for (size_t i = 0; i < 9; ++i) {
+        A.at(i / 3, i % 3) = dis(gen);
+      }
+
+      int int_det = 0;
+      bool singular = false;
+      try {
+        int_det = A.determinant();
+      } catch (const std::runtime_error &) {
+        singular = true;
+      }
+      if (singular) continue;
+
+      double dbl_det = A.cast<double>().determinant();
+      double rounded = std::round(dbl_det);
+      if (std::abs(dbl_det - rounded) > 1e-6) continue;
+
+      ++checked;
+      if (int_det != static_cast<int>(rounded)) {
+        ++mismatches;
+      }
+    }
+
+    ASSERT_TRUE(checked > 100);
+    ASSERT_TRUE(mismatches == 0);
+  }
+
+  //=============================================================================
   // MATRIX QR TESTS
   //=============================================================================
 
@@ -1503,6 +1691,27 @@ class MatrixTests : public ITest {
     should_handle_int_identity_matrix_in_cholesky();
     should_handle_diagonal_int_matrix_in_cholesky();
     cholesky_time_test();
+    should_compute_determinant_of_1x1_matrix();
+    should_compute_determinant_of_2x2_matrix();
+    should_compute_determinant_of_3x3_matrix();
+    should_compute_determinant_of_4x4_matrix();
+    should_compute_determinant_of_identity_matrix();
+    should_compute_determinant_of_diagonal_matrix();
+    should_compute_determinant_of_triangular_matrix();
+    should_compute_determinant_of_permutation_matrix();
+    should_throw_if_determinant_called_on_non_square_matrix();
+    should_throw_for_singular_matrix_when_computing_determinant();
+    should_throw_for_empty_matrix_when_computing_determinant();
+    should_compute_determinant_of_int_matrix();
+    should_promote_int_matrix_to_double_when_computing_determinant();
+    should_compute_determinant_of_float_matrix();
+    should_equal_determinant_of_transpose();
+    should_satisfy_determinant_multiplicativity();
+    should_compute_determinant_of_spd_matrix();
+    should_match_spd_and_plu_determinant_paths();
+    should_throw_if_spd_determinant_on_non_symmetric_matrix();
+    should_throw_if_spd_determinant_on_non_positive_definite_matrix();
+    should_match_int_determinant_with_double_precision_computation();
     should_decompose_identity_matrix_qr();
     should_decompose_known_small_matrix_qr();
     should_throw_on_empty_matrix();

--- a/tests/math/linalg/MatrixTests.cpp
+++ b/tests/math/linalg/MatrixTests.cpp
@@ -688,7 +688,7 @@ class MatrixTests : public ITest {
     math::Matrix<double> m(2, 3, {1, 2, 3, 4, 5, 6});
     bool thrown = false;
     try {
-      auto [P, L, U] = plu(m);
+      auto [P, L, U, s] = plu(m);
     } catch (const std::invalid_argument &e) {
       thrown = true;
     }
@@ -699,7 +699,7 @@ class MatrixTests : public ITest {
     math::Matrix<double> m(3, 3, {1, 2, 3, 2, 4, 6, 1, 2, 3});
     bool thrown = false;
     try {
-      auto [p, L, U] = math::plu(m);
+      auto [p, L, U, s] = plu(m);
     } catch (const std::runtime_error &e) {
       thrown = true;
     }
@@ -709,7 +709,7 @@ class MatrixTests : public ITest {
   void should_correctly_perform_plu_decomposition_on_small_matrix() {
     math::Matrix<double> A(3, 3, {2, 1, 1, 4, -6, 0, -2, 7, 2});
 
-    auto [p, L, U] = plu(A);
+    auto [p, L, U, s] = plu(A);
 
     ASSERT_TRUE(L.is_square() && U.is_square());
     ASSERT_TRUE(L.row_count() == 3 && U.row_count() == 3);
@@ -741,7 +741,7 @@ class MatrixTests : public ITest {
 
   void should_correctly_handle_identity_matrix_in_plu() {
     math::Matrix<double> I = math::identity_matrix<double>(3);
-    auto [P, L, U] = plu(I);
+    auto [P, L, U, s] = plu(I);
     ASSERT_TRUE(L == I);
     ASSERT_TRUE(U == I);
     for (size_t i = 0; i < 3; ++i) {
@@ -751,7 +751,7 @@ class MatrixTests : public ITest {
 
   void should_correctly_decompose_upper_triangular_matrix() {
     math::Matrix<double> U_true(3, 3, {1, 2, 3, 0, 4, 5, 0, 0, 6});
-    auto [P, L, U] = plu(U_true);
+    auto [P, L, U, s] = plu(U_true);
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = 0; j < 3; ++j) {
         ASSERT_TRUE(is_close(L.at(i, j), (i == j ? 1.0 : 0.0)));
@@ -770,7 +770,7 @@ class MatrixTests : public ITest {
 
   void should_correctly_handle_negative_pivots_in_plu() {
     math::Matrix<double> A(2, 2, {-4, -5, -2, -1});
-    auto [P, L, U] = plu(A);
+    auto [P, L, U, s] = plu(A);
     math::Matrix<double> Pm(2, 2);
 
     for (size_t i = 0; i < 2; ++i) {
@@ -795,7 +795,7 @@ class MatrixTests : public ITest {
     }
 
     auto start = std::chrono::high_resolution_clock::now();
-    auto [p, L, U] = plu(A);
+    auto [p, L, U, s] = plu(A);
 
     auto P = math::permutation_matrix<double>(p);
     auto end = std::chrono::high_resolution_clock::now();

--- a/tests/math/linalg/MatrixTests.cpp
+++ b/tests/math/linalg/MatrixTests.cpp
@@ -688,7 +688,7 @@ class MatrixTests : public ITest {
     math::Matrix<double> m(2, 3, {1, 2, 3, 4, 5, 6});
     bool thrown = false;
     try {
-      auto [P, L, U, s] = plu(m);
+      (void)plu(m);
     } catch (const std::invalid_argument &e) {
       thrown = true;
     }

--- a/tests/math/linalg/MatrixTests.cpp
+++ b/tests/math/linalg/MatrixTests.cpp
@@ -1003,7 +1003,8 @@ class MatrixTests : public ITest {
 
   void should_compute_determinant_of_4x4_matrix() {
     math::Matrix<double> m(4, 4, {1, 2, 3, 4, 5, 6, 7, 8, 2, -1, 0, 3, 9, 1, -2, 5});
-    ASSERT_TRUE(is_close(m.determinant(), -120.0));
+    static constexpr double EXPECTED = -120.0;
+    ASSERT_TRUE(is_close(m.determinant(), EXPECTED));
   }
 
   void should_compute_determinant_of_identity_matrix() {
@@ -1015,19 +1016,23 @@ class MatrixTests : public ITest {
 
   void should_compute_determinant_of_diagonal_matrix() {
     math::Matrix<double> m(3, 3, {9, 0, 0, 0, 16, 0, 0, 0, 25});
-    ASSERT_TRUE(is_close(m.determinant(), 3600.0));
+    static constexpr double EXPECTED = 3600.0;
+    ASSERT_TRUE(is_close(m.determinant(), EXPECTED));
   }
 
   void should_compute_determinant_of_triangular_matrix() {
     math::Matrix<double> m(3, 3, {1, 2, 3, 0, 4, 5, 0, 0, 6});
-    ASSERT_TRUE(is_close(m.determinant(), 24.0));
+    static constexpr double EXPECTED = 24.0;
+    ASSERT_TRUE(is_close(m.determinant(), EXPECTED));
   }
 
   void should_compute_determinant_of_permutation_matrix() {
-    math::Matrix<double> m(4, 4, {0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1});
+    math::Matrix<double> m1(4, 4, {0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1});
     math::Matrix<double> m2(3, 3, {1, 0, 0, 0, 0, 1, 0, 1, 0});
-    ASSERT_TRUE(is_close(m.determinant(), -1.0));
+    math::Matrix<double> m3(3, 3, {0, 0, 1, 1, 0, 0, 0, 1, 0});
+    ASSERT_TRUE(is_close(m1.determinant(), -1.0));
     ASSERT_TRUE(is_close(m2.determinant(), -1.0));
+    ASSERT_TRUE(is_close(m3.determinant(), 1.0));
   }
 
   void should_throw_if_determinant_called_on_non_square_matrix() {
@@ -1056,54 +1061,56 @@ class MatrixTests : public ITest {
     math::Matrix<int> m4(3, 3, {9, 0, 0, 0, 16, 0, 0, 0, 25});
     math::Matrix<int> I = math::identity_matrix<int>(3);
 
-    ASSERT_SAME_TYPE(m1.determinant(), int);
-    ASSERT_TRUE(m1.determinant() == -2);
-    ASSERT_TRUE(m2.determinant() == 2);
-    ASSERT_TRUE(m3.determinant() == -16);
-    ASSERT_TRUE(m4.determinant() == 3600);
-    ASSERT_TRUE(I.determinant() == 1);
+    ASSERT_SAME_TYPE(m1.determinant(), double);
+    ASSERT_TRUE(m1.determinant() == -2.0);
+    ASSERT_TRUE(m2.determinant() == 2.0);
+    ASSERT_TRUE(m3.determinant() == -16.0);
+    ASSERT_TRUE(m4.determinant() == 3600.0);
+    ASSERT_TRUE(I.determinant() == 1.0);
   }
 
   void should_promote_int_matrix_to_double_when_computing_determinant() {
-    // PLU/Cholesky promote integral matrices to double internally. These
-    // matrices have exact integer determinants but fractional intermediate
-    // factors, so the accumulator must not truncate during the computation.
     math::Matrix<int> m1(3, 3, {2, 3, 1, 4, 7, 5, 6, 8, 9});
     math::Matrix<int> m2(3, 3, {-7, -4, -8, -5, 0, -4, -7, -8, 8});
     math::Matrix<int> m3(2, 2, {3, 1, 1, 1});
-    ASSERT_TRUE(m1.determinant() == 18);
-    ASSERT_TRUE(m2.determinant() == -368);
-    ASSERT_TRUE(m3.determinant() == 2);
 
+    ASSERT_TRUE(is_close(m1.determinant(), 18));
+    ASSERT_TRUE(is_close(m2.determinant(), -368));
+    ASSERT_TRUE(is_close(m3.determinant(), 2));
+  }
+  void should_compute_determinant_of_spd_int_matrix() {
     math::Matrix<int> spd(3, 3, {4, 12, -16, 12, 37, -43, -16, -43, 98});
-    ASSERT_TRUE(spd.determinant<true>() == 36);
+    static constexpr double EXPECTED = 36.0;
+    ASSERT_TRUE(is_close(spd.determinant<true>(), EXPECTED));
   }
 
   void should_compute_determinant_of_float_matrix() {
     math::Matrix<float> m(
-        3, 3, {4.0f, 12.0f, -16.0f, 12.0f, 37.0f, -43.0f, -16.0f, -43.0f, 98.0f});
+        3, 3, {4.0F, 12.0F, -16.0F, 12.0F, 37.0F, -43.0F, -16.0F, -43.0F, 98.0F});
+    static constexpr double EXPECTED = 36.0F;
     ASSERT_SAME_TYPE(m.determinant(), float);
-    ASSERT_TRUE(is_close(m.determinant(), 36.0f, 1e-4f));
+    ASSERT_TRUE(is_close(m.determinant(), EXPECTED, 1e-4));
   }
 
   void should_equal_determinant_of_transpose() {
     math::Matrix<double> m(4, 4, {1, 2, 3, 4, 5, 6, 7, 8, 2, -1, 0, 3, 9, 1, -2, 5});
     double det = m.determinant();
     double det_t = m.transposed().determinant();
-    ASSERT_TRUE(is_close(det, -120.0));
+    static constexpr double EXPECTED = -120.0;
+    ASSERT_TRUE(is_close(det, EXPECTED));
     ASSERT_TRUE(is_close(det, det_t));
   }
 
   void should_satisfy_determinant_multiplicativity() {
     math::Matrix<double> A(3, 3, {2, 1, 1, 4, -6, 0, -2, 7, 2});
     math::Matrix<double> B(3, 3, {1, 2, 3, 0, 4, 5, 0, 0, 6});
-    double detA = A.determinant();
-    double detB = B.determinant();
-    double detAB = (A * B).determinant();
-    ASSERT_TRUE(is_close(detA, -16.0));
-    ASSERT_TRUE(is_close(detB, 24.0));
-    ASSERT_TRUE(is_close(detAB, detA * detB));
-    ASSERT_TRUE(is_close(detAB, -384.0));
+    double det_A = A.determinant();
+    double det_B = B.determinant();
+    double det_AB = (A * B).determinant();
+    ASSERT_TRUE(is_close(det_A, -16.0));
+    ASSERT_TRUE(is_close(det_B, 24.0));
+    ASSERT_TRUE(is_close(det_AB, det_A * det_B));
+    ASSERT_TRUE(is_close(det_AB, -384.0));
   }
 
   void should_compute_determinant_of_spd_matrix() {
@@ -1130,41 +1137,6 @@ class MatrixTests : public ITest {
   void should_throw_if_spd_determinant_on_non_positive_definite_matrix() {
     math::Matrix<double> m(2, 2, {1.0, 2.0, 2.0, 4.0});
     ASSERT_THROW((void)m.determinant<true>(), std::invalid_argument);
-  }
-
-  void should_match_int_determinant_with_double_precision_computation() {
-    std::mt19937 gen(42);
-    std::uniform_int_distribution<int> dis(-9, 9);
-    size_t checked = 0;
-    size_t mismatches = 0;
-
-    for (size_t trial = 0; trial < 500; ++trial) {
-      math::Matrix<int> A(3, 3);
-      for (size_t i = 0; i < 9; ++i) {
-        A.at(i / 3, i % 3) = dis(gen);
-      }
-
-      int int_det = 0;
-      bool singular = false;
-      try {
-        int_det = A.determinant();
-      } catch (const std::runtime_error &) {
-        singular = true;
-      }
-      if (singular) continue;
-
-      double dbl_det = A.cast<double>().determinant();
-      double rounded = std::round(dbl_det);
-      if (std::abs(dbl_det - rounded) > 1e-6) continue;
-
-      ++checked;
-      if (int_det != static_cast<int>(rounded)) {
-        ++mismatches;
-      }
-    }
-
-    ASSERT_TRUE(checked > 100);
-    ASSERT_TRUE(mismatches == 0);
   }
 
   //=============================================================================
@@ -1704,6 +1676,7 @@ class MatrixTests : public ITest {
     should_throw_for_empty_matrix_when_computing_determinant();
     should_compute_determinant_of_int_matrix();
     should_promote_int_matrix_to_double_when_computing_determinant();
+    should_compute_determinant_of_spd_int_matrix();
     should_compute_determinant_of_float_matrix();
     should_equal_determinant_of_transpose();
     should_satisfy_determinant_multiplicativity();
@@ -1711,7 +1684,6 @@ class MatrixTests : public ITest {
     should_match_spd_and_plu_determinant_paths();
     should_throw_if_spd_determinant_on_non_symmetric_matrix();
     should_throw_if_spd_determinant_on_non_positive_definite_matrix();
-    should_match_int_determinant_with_double_precision_computation();
     should_decompose_identity_matrix_qr();
     should_decompose_known_small_matrix_qr();
     should_throw_on_empty_matrix();


### PR DESCRIPTION
This pull request introduces several improvements to the linear algebra module, focusing on enhancing the PLU decomposition functionality and adding a determinant calculation method. The main changes include introducing a new `PLUResult` struct to encapsulate PLU decomposition results, updating the PLU implementation and all related usages, and adding a determinant calculation method to the `Matrix` class. Additionally, optimized matrix transpose operations for OpenBLAS are included.

**Linear Algebra Enhancements:**

* Added a `PLUResult` struct to encapsulate the permutation vector, lower and upper triangular matrices, and the permutation sign in PLU decomposition (`PLU.hpp`).
* Refactored the internal PLU decomposition implementation to return a `PLUResult` instead of a tuple, and updated the logic to track the sign of the permutation on row swaps (`PLU.hpp`). [[1]](diffhunk://#diff-bc6d1d62a1650cfb82a1c8766f1b89a5a78f91995cbc6d8f164846e0c939118aL32-R49) [[2]](diffhunk://#diff-bc6d1d62a1650cfb82a1c8766f1b89a5a78f91995cbc6d8f164846e0c939118aR64) [[3]](diffhunk://#diff-bc6d1d62a1650cfb82a1c8766f1b89a5a78f91995cbc6d8f164846e0c939118aR94) [[4]](diffhunk://#diff-bc6d1d62a1650cfb82a1c8766f1b89a5a78f91995cbc6d8f164846e0c939118aL158-R176)
* Updated all usages of `plu()` in the test suite to unpack the new `PLUResult` struct, ensuring compatibility with the refactored interface (`MatrixTests.cpp`). [[1]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL691-R691) [[2]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL702-R702) [[3]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL712-R712) [[4]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL744-R744) [[5]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL754-R754) [[6]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL773-R773) [[7]](diffhunk://#diff-5ed6fabea800d9de20fab10d7321f4625d2435b89aeba9b98e33552b788f0f6aL798-R798)

**Matrix Class Improvements:**

* Added a `determinant()` method to the `Matrix` class, supporting both general and symmetric positive definite (SPD) matrices, utilizing PLU or Cholesky decomposition as appropriate (`Matrix.hpp`).

**Performance Optimizations:**

* Added optimized matrix transpose implementations using OpenBLAS (`Matrix.hpp`).